### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ conda activate calvados
 ```
 (2. Only needed when planning to use GPUs: Install openmm via conda-force with cudatoolkit. This step can be skipped if running on CPU only.)
 ```
-conda install -c conda-forge openmm=8.2.0 cudatoolkit=11.2
+conda install -c conda-forge openmm=8.2.0 cudatoolkit=11.8
 ```
 3. Clone package and install CALVADOS and its dependencies using pip
 ``` 

--- a/calvados/build.py
+++ b/calvados/build.py
@@ -133,15 +133,13 @@ def build_compact(nbeads, d=0.38, verbose=False):
     cti, ctj, ctk = 0, 0, 0
     
     for idx in range(nbeads):
+        xs.append([i,j,k])
         if ctk == N:
             if ctj == N:
-                if cti == N:
-                    raise
-                else:
-                    i += di
-                    cti += 1
-                    ctj = 0
-                    dj *= -1
+                i += di
+                cti += 1
+                ctj = 0
+                dj *= -1
             else:
                 j += dj
                 ctj += 1
@@ -150,7 +148,6 @@ def build_compact(nbeads, d=0.38, verbose=False):
         else:
             k += dk
             ctk += 1
-        xs.append([i,j,k])
     xs = (np.array(xs) - 0.5*N) * d
     return xs
 

--- a/calvados/build.py
+++ b/calvados/build.py
@@ -123,6 +123,37 @@ def build_spiral(bondlengths, delta=0, arc=.38, separation=.7, n_per_res=1):
         r = b * phi
     return np.array(coords)+delta
 
+def build_compact(nbeads, d=0.38, verbose=False):
+    N = int(np.ceil(np.cbrt(nbeads)) - 1)
+    if verbose:
+        print(f'Building {N+1} * {N+1} * {N+1} grid.')
+    xs = []
+    i, j, k = 0, 0, 0
+    di, dj, dk = 1, 1, 1 # direction
+    cti, ctj, ctk = 0, 0, 0
+    
+    for idx in range(nbeads):
+        if ctk == N:
+            if ctj == N:
+                if cti == N:
+                    raise
+                else:
+                    i += di
+                    cti += 1
+                    ctj = 0
+                    dj *= -1
+            else:
+                j += dj
+                ctj += 1
+            ctk = 0
+            dk *= -1
+        else:
+            k += dk
+            ctk += 1
+        xs.append([i,j,k])
+    xs = (np.array(xs) - 0.5*N) * d
+    return xs
+
 def random_placement(box,xs_others,xinit,ntries=10000):
     ntry = 0
     while True: # random placement

--- a/calvados/data/default_config.yaml
+++ b/calvados/data/default_config.yaml
@@ -23,7 +23,7 @@ k_eq : 0.02
 steps_eq : 1000
 
 friction_coeff: 0.01 
-slab_width : 60
+slab_width : 100
 slab_outer : 40
 random_number_seed : null
 report_potential_energy : False

--- a/examples/single_IDR/prepare.py
+++ b/examples/single_IDR/prepare.py
@@ -51,7 +51,7 @@ analyses = f"""
 
 from calvados.analysis import save_rg
 
-save_rg("{path:s}","{sysname:s}","{residues_file:s}","data",10)
+save_rg("{path:s}","{sysname:s}","{residues_file:s}",".",10)
 """
 
 config.write(path,name='config.yaml',analyses=analyses)

--- a/examples/slab_IDR/prepare.py
+++ b/examples/slab_IDR/prepare.py
@@ -23,7 +23,6 @@ config = Config(
   ionic = 0.1, # molar
   pH = 7.5,
   topol = 'slab',
-  friction_coeff = 0.001,
 
   # RUNTIME SETTINGS
   wfreq = N_save, # dcd writing frequency, 1 = 10fs

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError:
 
 setup(
     name='calvados',
-    version='0.6.0',
+    version='0.6.1',
     description='Coarse-grained implicit-solvent simulations of biomolecules',
     url='https://github.com/KULL-Centre/CALVADOS',
     authors=[


### PR DESCRIPTION
Version 0.6.1

- Build protein IDR chains as 'compact' cuboid starting structures rather than spirals. This avoids clashes in some slab simulation set-ups in v.0.6.0. (RNA will still be built as spirals due to 2-bead-per-residue representation.)
- Re-implement three-letter amino acid code written in top.pdb