### PR TITLE
fix: providing self.box from sim.py when .pdb does not have it

### DIFF
--- a/calvados/build.py
+++ b/calvados/build.py
@@ -294,7 +294,7 @@ def build_xyzgrid(N,box):
     return xyz
 
 # FOLDED
-def geometry_from_pdb(pdb,use_com=False):
+def geometry_from_pdb(pdb, use_com=False, auto_box_margin=100., verbose=1):   # [A]
     """ positions in nm"""
     with catch_warnings():
         simplefilter("ignore")
@@ -310,7 +310,19 @@ def geometry_from_pdb(pdb,use_com=False):
     else:
         cas = u.select_atoms('name CA')
         pos = cas.positions / 10.
-    box = np.append(u.dimensions[:3]/10.,u.dimensions[3:])
+    
+    if(u.dimensions is None):   # the case when .pdb does not provide CRYST cell
+        if(auto_box_margin >= 0):
+            if(verbose > 0):
+                print(f'WARNING: did not find dimensions in PDB: {pdb}, automatically setting the box to the X-range + margin={auto_box_margin}[A]')
+            pos_size = np.amax(ag.positions, axis=0) - np.amin(ag.positions, axis=0)
+            u.dimensions = [pos_size[0] + auto_box_margin, pos_size[1] + auto_box_margin, pos_size[2] + auto_box_margin, 90, 90, 90]
+    
+    if(u.dimensions is None):
+        box = None
+    else:
+        box = np.append(u.dimensions[:3]/10., u.dimensions[3:])
+    
     return pos, box
 
 def geometry_from_pdb_rna(pdb,use_com=False):

--- a/calvados/sim.py
+++ b/calvados/sim.py
@@ -35,6 +35,9 @@ class Sim:
         self.comp_defaults = components['defaults']
 
         self.box = np.array(self.box)
+        if('dimensions' not in self.comp_defaults):   # Protein has attr 'dimensions', not 'box'
+            self.comp_defaults['dimensions'] = list(self.box) + [90.] * 3
+            self.comp_defaults['to_check_box'] = 1
         self.eps_lj *= 4.184 # kcal to kJ/mol
 
         if self.restart == 'checkpoint' and os.path.isfile(f'{self.path}/{self.frestart}'):
@@ -140,7 +143,6 @@ class Sim:
         self.system = openmm.System()
         a, b, c = build.build_box(self.box[0],self.box[1],self.box[2])
         self.system.setDefaultPeriodicBoxVectors(a, b, c)
-
 
         # init interaction parameters (required before make components)
         self.eps_yu, self.k_yu = interactions.genParamsDH(self.temp,self.ionic)


### PR DESCRIPTION
Addresses [this issue](https://github.com/KULL-Centre/CALVADOS/issues/40)

**Current behaviour:**
I tried running the AF-CALVADOS example, but it failed at the `box = np.append(u.dimensions[:3]/10., u.dimensions[3:])` line in `build.py`. 

The reason was: my `.pdb` from AF2 did not have a `CRYST` line, which resulted in `u.dimensions` being `None`.

**Desired behaviour:**
Actually, not 100% sure how the situation "L-box is provided in `config.yaml` but not in `*.pdb`" should be handled. More precisely, I think L-box should be passed to `Protein.dimensions`, but I am not sure at which level the L-box should be passed (`self.defaults` vs "a separate argument" vs ??).

**The provided fix:**

Pass the L-box info via `comp_defaults`.

All tests passed.

`sim.py`) Add the L-box info to the Sim.comp_defaults so that it is later propagated to child objects, e.g. Protein

`build.py`) The `geometry_from_pdb` returns `pos, box` always, meaning downstream code may rely on that. So, I added a default way to construct `box` when `.pdb` does not have the box info. 
The proposed default way: take the X-range of positions and add `auto_box_margin` to it (in Angstroms). The `verbose` option is to report this construction in case it's not intended. 

I actually think it'd better to make this `verbose=True` by default, but I wanted to utilize the already-present `verbose` from `calc_properties` (line 174 from `components.py`), which is `False` and may affect other things. Any thoughts on that?

Also, what should the `box` be in case it's not provided by `.pdb`, and also no auto-construction is requested (`auto_box_margin < 0`) ?

`components.py`) Handle the new default `Protein.dimensions`: skip reading it from `.pdb` if it is already present. Check the pre-existing box is consistent with the X-s from `.pdb`.

A related question: what should be prioritized if both `config.yaml` and `.pdb` provide L-box info?

